### PR TITLE
update: insert text to note

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -56,6 +56,25 @@ impl App {
                     .open_note(name, self.config.get_editor_data())?;
                 return Ok(Message::Empty);
             }
+            Command::Insert {
+                name,
+                text,
+                task,
+                list,
+            } => {
+                // make sure that only one of the formatting option (task, list) is true
+                if *task && *list {
+                    return Err(Error::ClapError(clap::error::Error::raw(
+                        clap::ErrorKind::ArgumentConflict,
+                        "pass either task or list",
+                    )));
+                }
+
+                self.vaults
+                    .ref_current()?
+                    .append_text(name, text, task, list)?;
+                return Ok(Message::TextAdded(name.to_owned()));
+            }
             Command::Folder { name } => {
                 self.vaults
                     .ref_current()?

--- a/src/output/error.rs
+++ b/src/output/error.rs
@@ -19,6 +19,7 @@ pub enum Error {
     OutOfBounds,
     EditorNotFound,
     MoveError(String), // this will be removed upon switching to custom recursive move fn
+    ClapError(clap::Error),
     Undefined(std::io::Error),
 }
 
@@ -51,6 +52,7 @@ impl Display for Error {
                 Error::OutOfBounds => "path crosses the bounds of vault".to_string(),
                 Error::EditorNotFound => "editor not found".to_string(),
                 Error::MoveError(msg) => msg.to_owned(),
+                Error::ClapError(err) => format!("{}", err),
                 Error::Undefined(error) => format!("undefined error: {}", error),
                 _ => "error msg not set".to_string(),
             }

--- a/src/output/message.rs
+++ b/src/output/message.rs
@@ -8,6 +8,7 @@ pub enum Message {
     ItemRenamed(Item, String, String),
     ItemMoved(Item, String),
     ItemVMoved(VaultItem, String, String),
+    TextAdded(String),
     FolderChanged,
     Config(ConfigType, String),
     ConfigSet(ConfigType, String),
@@ -39,6 +40,7 @@ impl Display for Message {
                     name,
                     vault_name
                 ),
+                Message::TextAdded(name) => format!("Line added to \x1b[0;34m{}\x1b[0m", name),
                 Message::FolderChanged => "changed folder".to_string(),
                 Message::Config(config_type, value) =>
                     format!("{}: \x1b[0;34m{}\x1b[0m", config_type.to_str(), value),

--- a/src/state/args.rs
+++ b/src/state/args.rs
@@ -31,6 +31,7 @@ create items
 interact with items
     \x1b[0;34menter\x1b[0m, \x1b[0;34men\x1b[0m       enter a vault
     \x1b[0;34mopen\x1b[0m, \x1b[0;34mop\x1b[0m        open a note from current folder
+    \x1b[0;34minsert\x1b[0m, \x1b[0;34madd\x1b[0m     append text to a note
     \x1b[0;34mchdir\x1b[0m, \x1b[0;34mcd\x1b[0m       change folder within current vault
     \x1b[0;34mlist\x1b[0m, \x1b[0;34mls\x1b[0m        print dir tree of current folder
 
@@ -89,6 +90,22 @@ pub enum Command {
         /// name of note to be opened
         #[clap(value_parser, name = "note name")]
         name: String,
+    },
+    /// append text to a node (from the current folder)
+    #[clap(alias = "in")]
+    Insert {
+        /// name of note to be edited
+        #[clap(value_parser, name = "note name")]
+        name: String,
+        /// text to be added
+        #[clap(value_parser, name = "text")]
+        text: String,
+        /// add line as a task
+        #[clap(long, short)]
+        task: bool,
+        /// add line as a list
+        #[clap(long, short)]
+        list: bool,
     },
     /// create a folder
     #[clap(override_usage("jt folder\n    jt folder [folder name]"))]

--- a/src/state/vaults/vault.rs
+++ b/src/state/vaults/vault.rs
@@ -3,8 +3,8 @@ use crate::{
     output::error::Error,
     traits::FileIO,
     utils::{
-        create_item, join_paths, move_item, process_path, rec_list, remove_item, rename_item,
-        run_editor,
+        append_to_file, create_item, join_paths, move_item, process_path, rec_list, remove_item,
+        rename_item, run_editor,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -154,6 +154,27 @@ impl Vault {
         let location = self.generate_location();
 
         run_editor(editor_data, name, &location)?;
+        Ok(())
+    }
+
+    pub fn append_text(
+        &self,
+        name: &str,
+        text: &String,
+        task: &bool,
+        list: &bool,
+    ) -> Result<(), Error> {
+        // either task/list is present at this point
+        let text = if *task {
+            format!("-[ ] {text}")
+        } else if *list {
+            format!("- {text}")
+        } else {
+            text.to_owned()
+        };
+        let location = self.generate_location();
+
+        append_to_file(name, text, &location)?;
         Ok(())
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,7 @@ use crate::{enums::Item, output::error::Error};
 use fs_extra::{dir::CopyOptions, move_items};
 use std::{
     fs::{remove_dir_all, remove_file, rename, DirBuilder, File},
+    io::Write,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -152,6 +153,24 @@ fn run_editor_collect(editor: &str, conflict: bool, path: &Path) -> Result<(), s
 
     if conflict {
         cmd.wait()?;
+    }
+
+    Ok(())
+}
+
+pub fn append_to_file(name: &str, text: String, location: &Path) -> Result<(), Error> {
+    let path = generate_item_path(&Item::Nt, name, location)?;
+
+    if !path.exists() {
+        return Err(Error::ItemNotFound(Item::Nt, name.to_string()));
+    }
+
+    let mut file = File::options().append(true).open(path).unwrap();
+    if let Err(err) = writeln!(file, "{text}") {
+        return Err(Error::FileError(
+            "Could not append to file".to_string(),
+            err,
+        ));
     }
 
     Ok(())


### PR DESCRIPTION
- Adds an option to append text to a note in the current vault's directory.
- The text can be appended as a list `- `  or as a task `-[ ] ` using the respective flags.

I'm not sure about the command name/alias, please suggest a new one as it seems fit! 